### PR TITLE
Add 'make clean'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ insert_final_newline = true
 
 [*.{yaml,yml}]
 indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ verify:
 
 build:
 	docker build -t "$(IMAGE_NAME):$(IMAGE_TAG)" .
+
+clean:
+	go clean
+	go clean -testcache


### PR DESCRIPTION
Go caches test results and re-uses them even when `TEST_ZONE_NAME` has been changed.