### PR TITLE
Add Information to readme regarding API Tokens containing a backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ type: Opaque
 data:
   api-key: your-key-base64-encoded
 ```
+Beware the API token does not work with the webhook, if it contains a backslash. The Go Json Marshal escapes the backslash, causing the API token to be invalid. 
+
+E.g. A sequence in the token of '\\\*' gets converted to '\\\\\*'.
 
 ### Create a certificate
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ type: Opaque
 data:
   api-key: your-key-base64-encoded
 ```
-Beware the API token does not work with the webhook, if it contains a backslash. The Go Json Marshal escapes the backslash, causing the API token to be invalid. 
+Beware the API token does not work with the webhook, if it contains a backslash. The Go Json library escapes the backslash, causing the API token to be invalid.
 
 E.g. A sequence in the token of '\\\*' gets converted to '\\\\\*'.
 


### PR DESCRIPTION
I had some issues with the webhook giving me an error that my API Token was not valid.
After validating with curl, that the token itself does work, I found that the Go Json Library escapes the backslash in my token and thus making it invalid.

I added to the Readme in the Credentials section a small warning regarding this behaviour.

The following sample code demonstrates the issue I was having:
```go
package main

import (
	"encoding/json"
	"fmt"
)

type JSONTestStruct struct {
	T string `json:"authToken"`
}

func main() {
	tS := &JSONTestStruct{}
	// One Backslash is used as escape and is not printed.
	tS.T = "\\*"
	// Verifies, that the string only has 2 characters and not 3.
	fmt.Printf("String Length: %d\n", len(tS.T))
	// prints \*
	fmt.Printf("'%s' before marshaling\n", tS.T)
	fi, _ := json.Marshal(tS)
	// prints {"authToken":"\\*"} instead of {"authToken":"\*"}
	fmt.Printf("'%s' after marshaling\n", string(fi))
}

```
